### PR TITLE
Add MOD: fix-mobile-page-padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ In addition, you can access the files in the `/DATA/AppData/casamod/icon` direct
 
 | Name | Description | Author |
 | ---- | ----------- | ------ |
+| fix-mobile-page-padding | Workaround for broken layout on some mobile browsers (like Brave Browser) 🩹 | jiesou |
 | snow-wallpaper | Add snow effect to wallpaper ❄️ | leaf-126 |
 | cn-fix-icon | Fixed app icon network error in China 🎨 | Cp0204 |
 | add-widget-saying | Merger of hello and quotable 👋 | ChishFoxcat |

--- a/README_CN.md
+++ b/README_CN.md
@@ -42,6 +42,7 @@
 
 | 名称 | 功能描述 | 作者 |
 | --- | -------- | ---- |
+| fix-mobile-page-padding | 临时修复某些手机浏览器（如 Brave）下页面布局错误 🩹 | jiesou |
 | snow-wallpaper | 给壁纸添加下雪效果 ❄️ | leaf-126 |
 | cn-fix-icon | 修复国内应用图标网络错误 🎨 | Cp0204 |
 | add-widget-saying | 头像和一言融合版本 👋 | ChishFoxcat |

--- a/app/mod/fix-moblie-page-padding/README.md
+++ b/app/mod/fix-moblie-page-padding/README.md
@@ -1,0 +1,14 @@
+# fix-mobile-page-padding
+
+一些手机上的浏览器（如 Brave Browser）在使用 CasaOS 时，底部导航栏会产生一些布局问题，这个 MOD 用以修复这些问题。
+
+修复的问题包括：
+- 应用设置底下的“保存”按钮消失
+- App Store 上方包含的“自定义安装”和关闭按钮的工具栏消失
+- 应用页顶部的返回按钮消失
+
+> 如果本来没有布局问题，是不用安装这个 MOD 的，否则可能让布局看上去很奇怪
+
+> CasaOS 本来的 CSS 写的就很乱，这个 fix 只能是暂时的 workaround。真的要解决，就看之后 CasaOS 怎么发展了。
+
+相关参考：https://github.com/brave/brave-browser/issues/47034

--- a/app/mod/fix-moblie-page-padding/mod.css
+++ b/app/mod/fix-moblie-page-padding/mod.css
@@ -1,0 +1,12 @@
+@media screen and (max-width: 768px) {
+    /*fix App Setting "Save" button below*/
+     div.animation-content > div.modal-card > section {
+        height: calc(-330px + 100vh)  !important;
+    }
+    /*fix App Store "Custom Install" buttom above*/
+    /*also fix App Store app page "Back" buttom above*/
+    div._stepStoreList {
+        margin-top: 120px !important;
+    }
+}
+


### PR DESCRIPTION
# fix-mobile-page-padding

一些手机上的浏览器（如 Brave Browser）在使用 CasaOS 时，底部导航栏会产生一些布局问题，这个 MOD 用以修复这些问题。

修复的问题包括：
- 应用设置底下的“保存”按钮消失
- App Store 上方包含的“自定义安装”和关闭按钮的工具栏消失
- 应用页顶部的返回按钮消失

> 如果本来没有布局问题，是不用安装这个 MOD 的，否则可能让布局看上去很奇怪

> CasaOS 本来的 CSS 写的就很乱，这个 fix 只能是暂时的 workaround。真的要解决，就看之后 CasaOS 怎么发展了。

相关参考：https://github.com/brave/brave-browser/issues/47034

测试截图：
![Screenshot_20250622-165101_Brave](https://github.com/user-attachments/assets/304b7421-9c6e-4366-b7c1-725402c6c6ce)
![Screenshot_20250622-165045_Brave](https://github.com/user-attachments/assets/39b520a6-d82a-4d25-9dec-720a7705d139)
